### PR TITLE
Fix null safety error for older flutter versions

### DIFF
--- a/lib/visibility_aware_state.dart
+++ b/lib/visibility_aware_state.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:visibility_aware_state/extensions.dart';
@@ -75,14 +77,14 @@ abstract class VisibilityAwareState<T extends StatefulWidget> extends State<T>
   void initState() {
     super.initState();
     //debugPrint('$runtimeType.initState()');
-    WidgetsBinding.instance.addPostFrameCallback(_onWidgetLoaded);
-    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance?.addPostFrameCallback(_onWidgetLoaded);
+    WidgetsBinding.instance?.addObserver(this);
   }
 
   void _onWidgetLoaded(_) {
     //debugPrint('$runtimeType.onWidgetLoaded()');
     _listeners.add(this);
-    WidgetsBinding.instance.addPersistentFrameCallback((timeStamp) {
+    WidgetsBinding.instance?.addPersistentFrameCallback((timeStamp) {
       //print(runtimeType);
       if (!_isWidgetRemoved && _addToStack(runtimeType.toString())) {
         //debugPrint('Adding $runtimeType to stack. widgetStack = $_widgetStack');
@@ -93,7 +95,7 @@ abstract class VisibilityAwareState<T extends StatefulWidget> extends State<T>
 
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
+    WidgetsBinding.instance?.removeObserver(this);
     //debugPrint('$runtimeType.dispose()');
     _isWidgetRemoved = true;
     _listeners.remove(this);


### PR DESCRIPTION
WidgetsBinding.instance is a nullable property and can not directly be called, instead prefer ?. safe call

```
../../.pub-cache/hosted/pub.dartlang.org/visibility_aware_state-1.0.5/lib/visibility_aware_state.dart:80:29: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../fvm/versions/2.8.1/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
    WidgetsBinding.instance.addPostFrameCallback(_onWidgetLoaded);
                            ^^^^^^^^^^^^^^^^^^^^
../../.pub-cache/hosted/pub.dartlang.org/visibility_aware_state-1.0.5/lib/visibility_aware_state.dart:81:29: Error: Method 'addObserver' cannot be called on 'WidgetsBinding?' because it is potentially null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../fvm/versions/2.8.1/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
    WidgetsBinding.instance.addObserver(this);
                            ^^^^^^^^^^^
../../.pub-cache/hosted/pub.dartlang.org/visibility_aware_state-1.0.5/lib/visibility_aware_state.dart:87:29: Error: Method 'addPersistentFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../fvm/versions/2.8.1/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
    WidgetsBinding.instance.addPersistentFrameCallback((timeStamp) {
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.pub-cache/hosted/pub.dartlang.org/visibility_aware_state-1.0.5/lib/visibility_aware_state.dart:98:29: Error: Method 'removeObserver' cannot be called on 'WidgetsBinding?' because it is potentially null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../fvm/versions/2.8.1/packages/flutter/lib/src/widgets/binding.dart').
Try calling using ?. instead.
    WidgetsBinding.instance.removeObserver(this);
                            ^^^^^^^^^^^^^^

```